### PR TITLE
Better visual separation of multiple calendar months

### DIFF
--- a/src/css/themes/light.css
+++ b/src/css/themes/light.css
@@ -79,10 +79,7 @@
     fill: #003064;
 }
 
-.a1-table ~ .a1-table .a1-tbody {
-    border-left: 1px solid rgba(211,211,211, 0.8);
-}
-
+.a1-table ~ .a1-table .a1-tbody,
 .a1-table ~ .a1-table .a1-thead > .a1-tr:last-child {
     border-left: 1px solid rgba(211,211,211, 0.8);
 }

--- a/src/css/themes/light.css
+++ b/src/css/themes/light.css
@@ -22,7 +22,7 @@
 }
 
 .a1-thead {
-    border-bottom: 1px solid rgba(211,211,211, 0.6);
+    border-bottom: 1px solid rgba(211,211,211, 0.8);
     padding-bottom: 1em;
 }
 
@@ -80,5 +80,9 @@
 }
 
 .a1-table ~ .a1-table .a1-tbody {
-    border-left: 1px solid rgba(211,211,211, 0.6);
+    border-left: 1px solid rgba(211,211,211, 0.8);
+}
+
+.a1-table ~ .a1-table .a1-thead > .a1-tr:last-child {
+    border-left: 1px solid rgba(211,211,211, 0.8);
 }


### PR DESCRIPTION
When multiple calendar months are displayed, the light borders generate a weak visual grouping, that may not suffice.
The pr aims to solve this by...
* chose a slightl darker border color for sibling tables
* also separate day names by border